### PR TITLE
fix for 1.8.5

### DIFF
--- a/lib/puppet/provider/printer/cups.rb
+++ b/lib/puppet/provider/printer/cups.rb
@@ -131,7 +131,7 @@ Puppet::Type.type(:printer).provide :cups, :parent => Puppet::Provider do
     options = {}
 
     # I'm using shellsplit here from the ruby std lib to avoid having to write a quoted string parser.
-    lpoptions('-d', destination).shellsplit.each do |kv|
+    Shellwords.shellwords(lpoptions('-d', destination)).each do |kv|
       values = kv.split('=')
       options[values[0]] = values[1]
     end


### PR DESCRIPTION
I ran into this small headache with our ruby 1.8.5 installs that was preventing the type from prefetching anything.
