### PR TITLE
look for the enable/disable/accept/reject commands in multiple directories with and without the cups prefix

### DIFF
--- a/lib/puppet/provider/printer/cups.rb
+++ b/lib/puppet/provider/printer/cups.rb
@@ -26,10 +26,54 @@ Puppet::Type.type(:printer).provide :cups, :parent => Puppet::Provider do
   commands :lpoptions => "/usr/bin/lpoptions"
   commands :lpstat => "/usr/bin/lpstat"
 
-  commands :cupsenable => "/usr/sbin/cupsenable"
-  commands :cupsdisable => "/usr/sbin/cupsdisable"
-  commands :cupsaccept => "/usr/sbin/cupsaccept"
-  commands :cupsreject => "/usr/sbin/cupsreject"
+  #
+  # candidate locations for the enable command
+  # Solaris 11 & Illumos/OpenIndiana have /usr/bin/{enable,disable}
+  #
+  [ "/usr/sbin/cupsenable",
+    "/usr/bin/cupsenable", 
+    "/usr/sbin/enable",
+    "/usr/bin/enable"].each do |cups_command|
+    if File.exists?(cups_command)
+      commands :cupsenable => cups_command
+      break
+    end
+  end
+
+  [ "/usr/sbin/cupsdisable",
+    "/usr/bin/cupsdisable", 
+    "/usr/sbin/disable",
+    "/usr/bin/disable"].each do |cups_command|
+    if File.exists?(cups_command)
+      commands :cupsdisable => cups_command
+      break
+    end
+  end
+
+  #
+  # Candidate locations for the accept and reject commands
+  # Older Fedora and RHEL/CentOS 6.x and earlier have /usr/sbin/{accept,reject}
+  # Solaris 11 & Illumos/OpenIndiana have the same.
+  #
+  [ "/usr/sbin/cupsaccept",
+    "/usr/bin/cupsaccept", 
+    "/usr/sbin/accept",
+    "/usr/bin/accept"].each do |cups_command|
+    if File.exists?(cups_command)
+      commands :cupsaccept => cups_command
+      break
+    end
+  end
+
+  [ "/usr/sbin/cupsreject",
+    "/usr/bin/cupsreject", 
+    "/usr/sbin/reject",
+    "/usr/bin/reject"].each do |cups_command|
+    if File.exists?(cups_command)
+      commands :cupsreject => cups_command
+      break
+    end
+  end
 
   mk_resource_methods
 


### PR DESCRIPTION
This is my first-ever pull request, so don't hesitate to point out all the things I've likely done incorrectly.

I'm also not very proficient with ruby, so stylistic and idiomatic changes are likely needed.

The basic idea is to not hardcode the paths to the binaries, instead searching for them in several possible locations, but with and without the "cups" prefix.  First one found wins.

There's no case that handles what happens if none are found.  That should probably be fixed.

Looking at some of the other providers that come with puppet 2.7.x, several of them don't use full paths to commands, they just use the command basename, e.g. "rpm".  That might be worth considering as an alternate approach.
