### PR TITLE
ignore lines not starting with 'printer' in lpstat -p

### DIFF
--- a/lib/facter/printers.rb
+++ b/lib/facter/printers.rb
@@ -5,9 +5,14 @@ Facter.add(:printers) do
     ENV['LANG'] = 'C'
     if printers_list = Facter::Util::Resolution.exec("/usr/bin/lpstat -p 2>/dev/null")
       printers = printers_list.split("\n").map do |line|
-        line.match(/printer (.*) is/).captures[0]
+        cap = line.match(/printer (.*) is/)
+        if cap.nil?
+          nil
+        else
+          cap.captures[0]
+        end
       end
-    printers.join(',')
+      printers.compact.join(',')
     end
   end
 end


### PR DESCRIPTION
sometimes the output of 'lpstat -p' contains lines like 'Printer is now
on-line' or 'Ready to print'. In these cases facter (or a puppet run)
outputs the following warning:

Could not retrieve printers: undefined method `captures' for nil:NilClass

This patch ignores lines not starting with 'printers'
