### PR TITLE
fix nil and regexp

### DIFF
--- a/lib/facter/printers.rb
+++ b/lib/facter/printers.rb
@@ -5,7 +5,7 @@ Facter.add(:printers) do
     ENV['LANG'] = 'C'
     if printers_list = Facter::Util::Resolution.exec("/usr/bin/lpstat -p 2>/dev/null")
       printers = printers_list.split("\n").map do |line|
-        cap = line.match(/printer (.*) is/)
+        cap = line.match(/^printer (.*?) /)
         if cap.nil?
           nil
         else


### PR DESCRIPTION
these two commits deal with corner cases in the output of 'lpstat -p':

1) sometimes the output of 'lpstat -p' contains lines like 'Printer is now
on-line' or 'Ready to print'. In these cases facter (or a puppet run)
outputs the following warning:

Could not retrieve printers: undefined method `captures' for nil:NilClass

This patch ignores lines not starting with 'printers'

2) when a printer is printing the lpstat output is: 'printer name now printing' 
and the previous regexp would skip the printer
