### PR TITLE
Fix for error when using tests.pp

### DIFF
--- a/tests/init.pp
+++ b/tests/init.pp
@@ -7,6 +7,7 @@ node default {
         uri          => "http://localhost",
         description  => "This is the printer description",
         location     => "John's office",
+        model        => 'drv:///sample.drv/generic.ppd',
         shared       => false,
         error_policy => abort_job,
     }


### PR DESCRIPTION
Applying `tests.pp` without this commit will leave `Printer_A` without model or PPD file. On the second run, Puppet will complain

```
Error: Could not prefetch printer provider 'cups': undefined method `captures' for nil:NilClass
```

because the call to `lpoptions -p Printer_A -l` returned

```
lpoptions: Unable to get PPD file for Printer_A: Not Found
```

Since the module does not (yet) verify or sanitize user input, I'll just suggest a fix here.

Note also, that the `tests.pp` passes (at least in Ubuntu 14.04 with CUPS 1.7.2) despite the apostrophe in the `location` property. Prefetch as well as `puppet resource printer` work on this example without error. Therefore I suggest to close issue #7.
