### PR TITLE
use unqualified command paths

### DIFF
--- a/lib/puppet/provider/default_printer/cups.rb
+++ b/lib/puppet/provider/default_printer/cups.rb
@@ -4,8 +4,8 @@ Puppet::Type.type(:default_printer).provide :cups, :parent => Puppet::Provider d
   This has no effect on the Mac OS X default destination, which is set via the GUI only.
   "
 
-  commands :lpoptions => '/usr/bin/lpoptions'
-  commands :lpstat => '/usr/bin/lpstat'
+  commands :lpoptions => 'lpoptions'
+  commands :lpstat => 'lpstat'
 
   def self.instances
     default = printer_default

--- a/lib/puppet/provider/printer/cups.rb
+++ b/lib/puppet/provider/printer/cups.rb
@@ -22,58 +22,26 @@ Puppet::Type.type(:printer).provide :cups, :parent => Puppet::Provider do
   a printer.
   "
 
-  commands :lpadmin => '/usr/sbin/lpadmin'
-  commands :lpoptions => '/usr/bin/lpoptions'
-  commands :lpstat => '/usr/bin/lpstat'
+  os = Facter.fact('os').value
+  os_family = os['family'].downcase
 
-  #
-  # candidate locations for the enable command
-  # Solaris 11 & Illumos/OpenIndiana have /usr/bin/{enable,disable}
-  #
-  [ "/usr/sbin/cupsenable",
-    "/usr/bin/cupsenable",
-    "/usr/sbin/enable",
-    "/usr/bin/enable"].each do |cups_command|
-    if File.exists?(cups_command)
-      commands :cupsenable => cups_command
-      break
-    end
+  commands :lpadmin => 'lpadmin'
+  commands :lpoptions => 'lpoptions'
+  commands :lpstat => 'lpstat'
+
+  # Solaris 11 & Illumos/OpenIndiana have /usr/bin/{enable,disable,accept,reject}
+  if os_family == 'solaris'
+    commands :cupsenable => 'enable'
+    commands :cupsdisable => 'disable'
+    commands :cupsaccept => 'accept'
+    commands :cupsreject => 'reject'
+  else
+    commands :cupsenable => 'cupsenable'
+    commands :cupsdisable => 'cupsdisable'
+    commands :cupsaccept => 'cupsaccept'
+    commands :cupsreject => 'cupsreject'
   end
 
-  [ "/usr/sbin/cupsdisable",
-    "/usr/bin/cupsdisable",
-    "/usr/sbin/disable",
-    "/usr/bin/disable"].each do |cups_command|
-    if File.exists?(cups_command)
-      commands :cupsdisable => cups_command
-      break
-    end
-  end
-
-  #
-  # Candidate locations for the accept and reject commands
-  # Older Fedora and RHEL/CentOS 6.x and earlier have /usr/sbin/{accept,reject}
-  # Solaris 11 & Illumos/OpenIndiana have the same.
-  #
-  [ "/usr/sbin/cupsaccept",
-    "/usr/bin/cupsaccept",
-    "/usr/sbin/accept",
-    "/usr/bin/accept"].each do |cups_command|
-    if File.exists?(cups_command)
-      commands :cupsaccept => cups_command
-      break
-    end
-  end
-
-  [ "/usr/sbin/cupsreject",
-    "/usr/bin/cupsreject",
-    "/usr/sbin/reject",
-    "/usr/bin/reject"].each do |cups_command|
-    if File.exists?(cups_command)
-      commands :cupsreject => cups_command
-      break
-    end
-  end
 
   mk_resource_methods
 

--- a/lib/puppet/provider/printer_defaults/cups_options.rb
+++ b/lib/puppet/provider/printer_defaults/cups_options.rb
@@ -11,8 +11,8 @@ Puppet::Type.type(:printer_defaults).provide :cups_options, :parent => Puppet::P
   Classes are parsed as normal printer destinations at the moment, and are interpreted as such.
   "
 
-  commands :lpoptions => "/usr/bin/lpoptions"
-  #commands :lpinfo => "/usr/sbin/lpinfo"
+  commands :lpoptions => "lpoptions"
+  #commands :lpinfo => "lpinfo"
 
   mk_resource_methods
 


### PR DESCRIPTION
This change resolves issue #50 during the first puppet run if cups is not installed. Some investigation into this issue revealed that `lib/puppet/prividers/printer/cups.rb` gets processed prior to any configuration.

When cups is not installed, commands `cupsenable`, `cupsdisable`, `cupsaccept`, and `cupsreject` are never set resulting, in the error `Could not evaluate: undefined method 'cupsenable' for #` as you can see in the below code snippet.
```
  [ "/usr/sbin/cupsenable",
    "/usr/bin/cupsenable",
    "/usr/sbin/enable",
    "/usr/bin/enable"].each do |cups_command|
    if File.exists?(cups_command)
      commands :cupsenable => cups_command
      break
    end
```
Essentially during a puppet run the following happens:
  - parse `lib/puppet/prividers/printer/cups.rb`
  - install cups
  - install printer (fails because cups.rb was parsed before cups was installed)

By using unqualified binary paths we rely on the system path and therefore don't have worry if the binary is in `/usr/bin` or `/usr/sbin`. 

From the [puppet documentation](https://docs.puppetlabs.com/guides/provider_development.html)
> The binary can be fully qualified, in which case that specific path is required, or it can be unqualified, in which case Puppet will find the binary in the shell path and use that. If the binary cannot be found, then the provider is considered unsuitable.

With this patch, if the user does not have cups installed and does not `include cups` they will get this error message `Error: Could not find a suitable provider for printer`, however puppet will complete the run without aborting.