### PR TITLE
Add empty default for cups::printers hiera lookup

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class cups (
   include '::cups::service'
 
   $printers_default = { ensure => present }
-  create_resources('printer', hiera_hash(cups::printers), $printers_default)
+  create_resources('printer', hiera_hash(cups::printers, { }), $printers_default)
 
   if $cups::cups_lpd_enable {
       include '::cups::config'


### PR DESCRIPTION
The Hiera variable cups::printers has been added to allow end users to define their printers in hiera and require no additional puppet manifest code than 'include cups'.

However by not including a default option the puppet manifest will fail if the user does not specify cups::printer in Hiera.

This change will add a blank hash to the hiera_hash call so that if it returns nothing then no error is logged and no printers created