### PR TITLE
Clean up the manifests

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,12 +1,12 @@
-class cups::config (
-) {
-    if $cups::cups_lpd_enable {
-        file { '/etc/xinetd.d/cups-lpd':
-          ensure  => file,
-          owner   => 'root',
-          group   => 'root',
-          mode    => '0644',
-          source  => $cups::config_file,
-        }
+# Configures various aspects of CUPS
+class cups::config {
+  if $::cups::cups_lpd_enable {
+    file { '/etc/xinetd.d/cups-lpd':
+      ensure => file,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
+      source => $::cups::config_file,
     }
+  }
 }

--- a/manifests/devel.pp
+++ b/manifests/devel.pp
@@ -1,6 +1,6 @@
-#
+# Installs the development packages
 class cups::devel {
-    package { $cups::package_devel:
-        ensure  => $cups::ensure,
-    }
+  package { $::cups::package_devel:
+    ensure  => $::cups::ensure,
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,17 +1,15 @@
+# Manages the Common UNIX Printing System (CUPS)
 class cups (
-  $package_ensure = $cups::params::package_ensure,
-  $package_name = $cups::params::package_name,
-
-  $devel_package_ensure = $cups::params::devel_package_ensure,
-  $devel_package_name = $cups::params::devel_package_name,
-
-  $service_ensure = $cups::params::service_ensure,
-  $service_enabled = $cups::params::service_enabled,
-  $service_name = $cups::params::service_name,
-
-  $cups_lpd_enable = $cups::params::cups_lpd_enable,
-  $package_cups_lpd = $cups::params::package_cups_lpd,
-  $config_file = $cups::params::config_file,
+  $package_ensure       = $::cups::params::package_ensure,
+  $package_name         = $::cups::params::package_name,
+  $devel_package_ensure = $::cups::params::devel_package_ensure,
+  $devel_package_name   = $::cups::params::devel_package_name,
+  $service_ensure       = $::cups::params::service_ensure,
+  $service_enabled      = $::cups::params::service_enabled,
+  $service_name         = $::cups::params::service_name,
+  $cups_lpd_enable      = $::cups::params::cups_lpd_enable,
+  $package_cups_lpd     = $::cups::params::package_cups_lpd,
+  $config_file          = $::cups::params::config_file,
 ) inherits cups::params {
 
   include '::cups::install'
@@ -20,7 +18,7 @@ class cups (
   $printers_default = { ensure => present }
   create_resources('printer', hiera_hash(cups::printers), $printers_default)
 
-  if $cups::cups_lpd_enable {
-      include '::cups::config'
+  if $cups_lpd_enable {
+    include '::cups::config'
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,14 +1,14 @@
-class cups::install (
-) {
-    package { 'cups':
-        name    => $cups::package_name,
-        ensure  => $cups::package_ensure,
+# Installs CUPS and related components
+class cups::install {
+  package { 'cups':
+    ensure => $::cups::package_ensure,
+    name   => $::cups::package_name,
+  }
+
+  if $::cups::cups_lpd_enable {
+    package { 'cups-lpd':
+      ensure => $::cups::package_ensure,
+      name   => $::cups::package_cups_lpd,
     }
-    
-    if $cups::cups_lpd_enable {
-        package { 'cups-lpd':
-            name    => $cups::package_cups_lpd,
-            ensure  => $cups::package_ensure,
-        }
-    }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,16 +1,17 @@
+# Various default parmeters
 class cups::params {
-  $package_ensure = present
-  $package_name = 'cups'
+  $package_ensure       = present
+  $package_name         = 'cups'
 
   $devel_package_ensure = undef
-  $devel_package_name = "${package_name}-devel"
+  $devel_package_name   = "${package_name}-devel"
 
-  $service_ensure = 'running'
-  $service_enabled = true
-  $service_name = 'cups'
+  $service_ensure       = 'running'
+  $service_enabled      = true
+  $service_name         = 'cups'
 
-  $cups_lpd_enable = false
-  $cups_lpd_ensure = 'running'
-  $package_cups_lpd = 'cups-lpd'
-  $config_file = 'puppet:///modules/cups/cups-lpd'
+  $cups_lpd_enable      = false
+  $cups_lpd_ensure      = 'running'
+  $package_cups_lpd     = 'cups-lpd'
+  $config_file          = 'puppet:///modules/cups/cups-lpd'
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,20 +1,21 @@
-class cups::service () {
+# Manages the CUPS service
+class cups::service {
 
-    service { 'cups':
-        ensure     => $cups::service_ensure,
-        enable     => $cups::service_enabled,
-        hasstatus  => true,
-        hasrestart => true,
-        require    => Class['cups::install'],
-    }
+  service { 'cups':
+    ensure     => $::cups::service_ensure,
+    enable     => $::cups::service_enabled,
+    hasstatus  => true,
+    hasrestart => true,
+    require    => Class['cups::install'],
+  }
 
-    if $cups::cups_lpd_enable {
-        service { 'xinetd':
-            ensure     => $cups::cups_lpd_ensure,
-            enable     => $cups::cups_lpd_enable,
-            hasstatus  => true,
-            hasrestart => true,
-            subscribe  => File['/etc/xinetd.d/cups-lpd'],
-        }
+  if $::cups::cups_lpd_enable {
+    service { 'xinetd':
+      ensure     => $::cups::cups_lpd_ensure,
+      enable     => $::cups::cups_lpd_enable,
+      hasstatus  => true,
+      hasrestart => true,
+      subscribe  => File['/etc/xinetd.d/cups-lpd'],
     }
+  }
 }


### PR DESCRIPTION
This makes several changes to clean up the Puppet code.  With this it
mostly pass puppet-lint using the default settings, inherits from params
notwithstanding.  It also tabularizes key/value pair lists, removes some
blank lines and makes variable scope explicit.