### PR TITLE
Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 2.0.0"
-    },
+    }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
extra comma is causing librarian-puppet to choke.

```bash
[Librarian] Resolving mosen-cups (>= 0) <https://github.com/mosen/puppet-cups.git#master>
[Librarian]   Checking manifests
[Librarian]     --- No output
[Librarian]     --- No output
[Librarian]     --- No output
[Librarian]     --- No output
[Librarian]     --- No output
[Librarian]     --> origin
[Librarian]     -->   origin/HEAD -> origin/master
[Librarian]     -->   origin/feature/multicmd
[Librarian]     -->   origin/feature/ppd_options_params
[Librarian]     -->   origin/feature/prefetch-only
[Librarian]     -->   origin/feature/uri_change
[Librarian]     -->   origin/master
[Librarian]     -->   origin/release/1.3.0
[Librarian]     --> 09684568f931a819fc009f34b568e0160c07a331
[Librarian]     --> 09684568f931a819fc009f34b568e0160c07a331
/opt/boxen/repo/.bundle/ruby/2.0.0/gems/json-1.8.3/lib/json/common.rb:155:in `parse': 399: unexpected token at '], (JSON::ParserError)
  "operatingsystem_support": [
    {
      "operatingsystem":"Darwin",
      "operatingsystemrelease":[ "13.4" ]
    },
    {
      "operatingsystem":"CentOS",
      "operatingsystemrelease":[ "6.4", "6.5", "6.6" ]
    },
    {
      "operatingsystem": "Ubuntu",
      "operatingsystemrelease": [ "12.04", "10.04" ]
    }
  ]
}
'
```