### PR TITLE
puppet 4 compatibility

### DIFF
--- a/lib/puppet/provider/printer/cups.rb
+++ b/lib/puppet/provider/printer/cups.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:printer).provide :cups, :parent => Puppet::Provider do
   a printer.
   "
 
-  os = Facter.fact('os').value
+  os = Facter.value(:os)
   os_family = os['family'].downcase
 
   commands :lpadmin => 'lpadmin'


### PR DESCRIPTION
Facter.fact has been removed in puppet4/facter3

> Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Resource Statement, Could not autoload puppet/type/printer: Could not autoload puppet/provider/printer/cups: undefined method `fact' for Facter:Module

https://tickets.puppetlabs.com/browse/MODULES-2246
https://github.com/puppetlabs/puppetlabs-firewall/commit/38c66d5fb2dabc96b4f78186ecd712743232c36d