### PR TITLE
Add package install options

### DIFF
--- a/manifests/devel.pp
+++ b/manifests/devel.pp
@@ -2,6 +2,6 @@
 class cups::devel {
   package { $::cups::package_devel:
     ensure          => $::cups::ensure,
-    install_options => $::cups::package_devel_install_options,
+    install_options => $::cups::package_install_options,
   }
 }

--- a/manifests/devel.pp
+++ b/manifests/devel.pp
@@ -1,6 +1,7 @@
 # Installs the development packages
 class cups::devel {
   package { $::cups::package_devel:
-    ensure  => $::cups::ensure,
+    ensure          => $::cups::ensure,
+    install_options => $::cups::package_devel_install_options,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,16 +1,19 @@
 # Manages the Common UNIX Printing System (CUPS)
 class cups (
-  $default_printer      = undef,
-  $package_ensure       = $::cups::params::package_ensure,
-  $package_name         = $::cups::params::package_name,
-  $devel_package_ensure = $::cups::params::devel_package_ensure,
-  $devel_package_name   = $::cups::params::devel_package_name,
-  $service_ensure       = $::cups::params::service_ensure,
-  $service_enabled      = $::cups::params::service_enabled,
-  $service_name         = $::cups::params::service_name,
-  $cups_lpd_enable      = $::cups::params::cups_lpd_enable,
-  $package_cups_lpd     = $::cups::params::package_cups_lpd,
-  $config_file          = $::cups::params::config_file,
+  $default_printer                  = undef,
+  $package_ensure                   = $::cups::params::package_ensure,
+  $package_name                     = $::cups::params::package_name,
+  $package_install_options          = $::cups::params::package_install_options,
+  $devel_package_ensure             = $::cups::params::devel_package_ensure,
+  $devel_package_name               = $::cups::params::devel_package_name,
+  $devel_package_install_options    = $::cups::params::devel_package_install_options,
+  $service_ensure                   = $::cups::params::service_ensure,
+  $service_enabled                  = $::cups::params::service_enabled,
+  $service_name                     = $::cups::params::service_name,
+  $cups_lpd_enable                  = $::cups::params::cups_lpd_enable,
+  $package_cups_lpd                 = $::cups::params::package_cups_lpd,
+  $package_cups_lpd_install_options = $::cups::params::package_cups_lpd_install_options,
+  $config_file                      = $::cups::params::config_file,
 ) inherits cups::params {
 
   include '::cups::install'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,19 +1,17 @@
 # Manages the Common UNIX Printing System (CUPS)
 class cups (
-  $default_printer                  = undef,
-  $package_ensure                   = $::cups::params::package_ensure,
-  $package_name                     = $::cups::params::package_name,
-  $package_install_options          = $::cups::params::package_install_options,
-  $devel_package_ensure             = $::cups::params::devel_package_ensure,
-  $devel_package_name               = $::cups::params::devel_package_name,
-  $devel_package_install_options    = $::cups::params::devel_package_install_options,
-  $service_ensure                   = $::cups::params::service_ensure,
-  $service_enabled                  = $::cups::params::service_enabled,
-  $service_name                     = $::cups::params::service_name,
-  $cups_lpd_enable                  = $::cups::params::cups_lpd_enable,
-  $package_cups_lpd                 = $::cups::params::package_cups_lpd,
-  $package_cups_lpd_install_options = $::cups::params::package_cups_lpd_install_options,
-  $config_file                      = $::cups::params::config_file,
+  $default_printer         = undef,
+  $package_ensure          = $::cups::params::package_ensure,
+  $package_name            = $::cups::params::package_name,
+  $package_install_options = $::cups::params::package_install_options,
+  $devel_package_ensure    = $::cups::params::devel_package_ensure,
+  $devel_package_name      = $::cups::params::devel_package_name,
+  $service_ensure          = $::cups::params::service_ensure,
+  $service_enabled         = $::cups::params::service_enabled,
+  $service_name            = $::cups::params::service_name,
+  $cups_lpd_enable         = $::cups::params::cups_lpd_enable,
+  $package_cups_lpd        = $::cups::params::package_cups_lpd,
+  $config_file             = $::cups::params::config_file,
 ) inherits cups::params {
 
   include '::cups::install'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,14 +1,16 @@
 # Installs CUPS and related components
 class cups::install {
   package { 'cups':
-    ensure => $::cups::package_ensure,
-    name   => $::cups::package_name,
+    ensure          => $::cups::package_ensure,
+    name            => $::cups::package_name,
+    install_options => $::cups::package_install_options,
   }
 
   if $::cups::cups_lpd_enable {
     package { 'cups-lpd':
-      ensure => $::cups::package_ensure,
-      name   => $::cups::package_cups_lpd,
+      ensure          => $::cups::package_ensure,
+      name            => $::cups::package_cups_lpd,
+      install_options => $::cups::package_cups_lpd_install_options,
     }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,7 +10,7 @@ class cups::install {
     package { 'cups-lpd':
       ensure          => $::cups::package_ensure,
       name            => $::cups::package_cups_lpd,
-      install_options => $::cups::package_cups_lpd_install_options,
+      install_options => $::cups::package_install_options,
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,17 +1,19 @@
 # Various default parmeters
 class cups::params {
-  $package_ensure       = present
-  $package_name         = 'cups'
+  $package_ensure                = present
+  $package_name                  = 'cups'
+  $package_install_options       = undef
 
-  $devel_package_ensure = undef
-  $devel_package_name   = "${package_name}-devel"
+  $devel_package_ensure          = undef
+  $devel_package_name            = "${package_name}-devel"
+  $devel_package_install_options = undef
 
-  $service_ensure       = 'running'
-  $service_enabled      = true
-  $service_name         = 'cups'
+  $service_ensure                = 'running'
+  $service_enabled               = true
+  $service_name                  = 'cups'
 
-  $cups_lpd_enable      = false
-  $cups_lpd_ensure      = 'running'
-  $package_cups_lpd     = 'cups-lpd'
-  $config_file          = 'puppet:///modules/cups/cups-lpd'
+  $cups_lpd_enable               = false
+  $cups_lpd_ensure               = 'running'
+  $package_cups_lpd              = 'cups-lpd'
+  $config_file                   = 'puppet:///modules/cups/cups-lpd'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,6 @@ class cups::params {
 
   $devel_package_ensure             = undef
   $devel_package_name               = "${package_name}-devel"
-  $devel_package_install_options    = undef
 
   $service_ensure                   = 'running'
   $service_enabled                  = true
@@ -15,6 +14,5 @@ class cups::params {
   $cups_lpd_enable                  = false
   $cups_lpd_ensure                  = 'running'
   $package_cups_lpd                 = 'cups-lpd'
-  $package_cups_lpd_install_options = undef
   $config_file                      = 'puppet:///modules/cups/cups-lpd'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,19 +1,20 @@
 # Various default parmeters
 class cups::params {
-  $package_ensure                = present
-  $package_name                  = 'cups'
-  $package_install_options       = undef
+  $package_ensure                   = present
+  $package_name                     = 'cups'
+  $package_install_options          = undef
 
-  $devel_package_ensure          = undef
-  $devel_package_name            = "${package_name}-devel"
-  $devel_package_install_options = undef
+  $devel_package_ensure             = undef
+  $devel_package_name               = "${package_name}-devel"
+  $devel_package_install_options    = undef
 
-  $service_ensure                = 'running'
-  $service_enabled               = true
-  $service_name                  = 'cups'
+  $service_ensure                   = 'running'
+  $service_enabled                  = true
+  $service_name                     = 'cups'
 
-  $cups_lpd_enable               = false
-  $cups_lpd_ensure               = 'running'
-  $package_cups_lpd              = 'cups-lpd'
-  $config_file                   = 'puppet:///modules/cups/cups-lpd'
+  $cups_lpd_enable                  = false
+  $cups_lpd_ensure                  = 'running'
+  $package_cups_lpd                 = 'cups-lpd'
+  $package_cups_lpd_install_options = undef
+  $config_file                      = 'puppet:///modules/cups/cups-lpd'
 }


### PR DESCRIPTION
In our environment, Avahi will cause DNS resolution problems (we use a .local domain name). When cups is installed with Puppet, Avahi is also installed. This then breaks the execution of the Puppet script as thre's no DNS resolution after Avahi is installed. This PR adds the optional parameter package_install_options (default to undef) so one can pass --no-install-recommends and not install Avahi. Example:

class { 'cups':
  package_install_options => ['--no-install-recommends'],
}
