### PR TITLE
More liberal regex for matching ppd option values

### DIFF
--- a/lib/puppet/provider/printer/cups.rb
+++ b/lib/puppet/provider/printer/cups.rb
@@ -241,7 +241,7 @@ Puppet::Type.type(:printer).provide :cups, :parent => Puppet::Provider do
         kv = line.split(':')
         key = kv[0].split('/', 2)[0]
 
-        selected_value = /\*(\w+)/.match(kv[1]).captures[0]
+        selected_value = /\*(\S+)/.match(kv[1]).captures[0]
 
         hash[key] = selected_value
         hash


### PR DESCRIPTION
Allows matching other valid non-whitespace characters not included in \w character class, e.g. "-"
Address issue discovered in #63 